### PR TITLE
Update README to remove manual installation section typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ systemctl daemon-reload
 systemctl enable --now coolerdash.service
 ```
 
-#### All Distributions (Manual Installation)
+#### All Distributions
 
 - Manual installation:
 


### PR DESCRIPTION
Removed 'Manual Installation' subsection from README.