### PR TITLE
docs: Simplify installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@
 # STEP 1: Install
 yay -S coolerdash-git
 #OR any other AUR helper
-
-# STEP 2: Reload systemd configuration
-systemctl daemon-reload
-
-# STEP 3: Restart CoolerControl to load the plugin
-sudo systemctl restart coolercontrold
 ```
 
 #### All distributions
@@ -84,12 +78,6 @@ cd coolerdash
 
 # STEP 2: Build and install (auto-detects Linux distribution and installs dependencies)
 make install
-
-# STEP 3: Reload systemd configuration
-systemctl daemon-reload
-
-# STEP 4: Restart CoolerControl to load the plugin
-sudo systemctl restart coolercontrold
 ```
 
 > For manual installations, make sure all required dependencies are installed correctly. Manual installations need to be updated manually.


### PR DESCRIPTION
Removed unnecessary steps for systemd configuration and restarting CoolerControl from the installation instructions.