### PR TITLE
fix: widen lcd_orientation to uint16_t (fixes orientation=270)

### DIFF
--- a/src/device/config.c
+++ b/src/device/config.c
@@ -1072,7 +1072,7 @@ static void load_display_from_json(json_t *root, Config *config)
     {
         int val = (int)json_integer_value(orientation);
         if (is_valid_orientation(val))
-            config->lcd_orientation = (uint8_t)val;
+            config->lcd_orientation = (uint16_t)val;
     }
 
     json_t *width = json_object_get(display, "width");

--- a/src/device/config.h
+++ b/src/device/config.h
@@ -95,7 +95,7 @@ typedef struct Config
     uint16_t display_height;
     float display_refresh_interval;
     uint8_t lcd_brightness;
-    uint8_t lcd_orientation;
+    uint16_t lcd_orientation; // 0/90/180/270
     char display_mode[16];
     char display_background_image_fit[16];
     uint16_t circle_switch_interval;


### PR DESCRIPTION
Hi! Quick PR — I'm not a developer, just a user who hit this bug on my Kraken 2023 Elite. Claude Code figured out what was wrong and wrote the patch. Sharing in case it helps anyone else, but please review carefully.

The bug: `display.orientation = 270` in config silently ends up as `0` because `lcd_orientation` is `uint8_t`. In `load_display_from_json()` the cast `(uint8_t)270` truncates to `14` (`270 & 0xFF`). Then `set_display_defaults()` runs `is_valid_orientation(14)` → false → resets the field to `0`. So coolerdash POSTs `"orientation": 0` to CoolerControl every refresh, which overrides whatever you set in CC's native UI a few seconds later.

That explains why only 270 is broken on the Elite — 90 and 180 fit in a uint8_t.

Fix: widen the field to `uint16_t` and the matching cast. `is_valid_orientation()` already takes `int` so no other call sites change. Builds clean with `-Wall -Wextra`.

```diff
--- a/src/device/config.h
+++ b/src/device/config.h
@@ -95,7 +95,7 @@
     uint8_t lcd_brightness;
-    uint8_t lcd_orientation;
+    uint16_t lcd_orientation; // 0/90/180/270

--- a/src/device/config.c
+++ b/src/device/config.c
@@ -1072,7 +1072,7 @@
         if (is_valid_orientation(val))
-            config->lcd_orientation = (uint8_t)val;
+            config->lcd_orientation = (uint16_t)val;
```

Tested on NZXT Kraken 2023 Elite (`1e71:300c`, fw 2.0.0), CoolerControl 4.3.0, coolerdash 3.1.4 (`b1b73d11`). Before: LCD never rotates to 270°; setting 270° in CC UI works for ~3.5 s then gets overridden. After: rotates to 270° and stays. Verified visually.

Probably closes the orient piece of #86 (the Elite 360 "bucket" flicker in that thread looks unrelated).

Thanks for the project!
