### PR TITLE
fix: raise sensor cap and remap UI sensor list

### DIFF
--- a/etc/coolercontrol/plugins/coolerdash/ui/index.html
+++ b/etc/coolercontrol/plugins/coolerdash/ui/index.html
@@ -1552,21 +1552,42 @@
             return [];
         }
 
-        // Normalize getStatus() return value: cc-plugin-lib returns a Map or { devices: [...] },
-        // the REST API returns { devices: [...] }.
+        // Normalize getStatus() return value: cc-plugin-lib returns a Map, the REST API
+        // returns { devices: [...] }. Both come back as the REST shape so callers read one.
         function normalizeStatus(raw) {
             if (!raw) return [];
             if (Array.isArray(raw)) return raw;
-            if (raw instanceof Map) {
-                // Map keyed by uid, values are status objects
-                var arr = [];
-                raw.forEach(function(val, key) {
-                    arr.push(typeof val === 'object' ? Object.assign({ uid: key }, val) : { uid: key });
-                });
-                return arr;
-            }
+            if (raw instanceof Map) return statusFromMap(raw);
             if (Array.isArray(raw.devices)) return raw.devices;
             return [];
+        }
+
+        // cc-plugin-lib's getStatus() yields Map<uid, Map<name, {temp,rpm,duty,freq,watts}>>,
+        // where every value is a preformatted string. The inner Map holds its entries in
+        // internal slots, so it cannot be spread or Object.assign'd; it has to be walked.
+        function statusFromMap(raw) {
+            var devices = [];
+            raw.forEach(function(sensors, uid) {
+                var temps = [];
+                var channels = [];
+                if (sensors instanceof Map) {
+                    sensors.forEach(function(values, name) {
+                        if (values.temp !== undefined) {
+                            temps.push({ name: name, temp: parseFloat(values.temp) });
+                        }
+                        var channel = { name: name };
+                        var found = false;
+                        ['rpm', 'duty', 'watts', 'freq'].forEach(function(field) {
+                            if (values[field] === undefined) return;
+                            channel[field] = parseFloat(values[field]);
+                            found = true;
+                        });
+                        if (found) channels.push(channel);
+                    });
+                }
+                devices.push({ uid: uid, status_history: [{ temps: temps, channels: channels }] });
+            });
+            return devices;
         }
 
         function splitPatternList(patternList) {

--- a/src/srv/cc_sensor.c
+++ b/src/srv/cc_sensor.c
@@ -93,7 +93,18 @@ static int add_sensor_entry(monitor_sensor_data_t *data,
                             float value, const char *unit, int use_decimal)
 {
     if (data->sensor_count >= MAX_SENSORS)
+    {
+        /* Once: reached for every sensor over the cap, on every poll. */
+        static int overflow_reported = 0;
+        if (!overflow_reported)
+        {
+            overflow_reported = 1;
+            log_message(LOG_WARNING,
+                        "More than %d sensors; '%s' on %s and later ones are unavailable.",
+                        MAX_SENSORS, name, get_device_name_by_uid(device_uid));
+        }
         return 0;
+    }
 
     sensor_entry_t *entry = &data->sensors[data->sensor_count];
     cc_safe_strcpy(entry->name, sizeof(entry->name), name);

--- a/src/srv/cc_sensor.h
+++ b/src/srv/cc_sensor.h
@@ -27,7 +27,9 @@ struct Config;
 // Sensor Data Model Constants
 // ============================================================================
 
-#define MAX_SENSORS 64
+/* One entry per temperature and per channel across every device. A desktop with service
+   plugins and custom sensors passes 64. */
+#define MAX_SENSORS 256
 #define SENSOR_NAME_LEN 48
 #define SENSOR_UID_LEN 96
 #define SENSOR_DEVICE_NAME_LEN 64


### PR DESCRIPTION
Hi 👋🏼 

2 small fixes:
- The sensor cap doesn't affect many people, but for sure my machine has >64 sensors, which causes my CPU temp to occasionally be dropped and reads 0 on the LCD.
- I noticed the Sensors page kept saying that it couldn't read all the sensors. This is kind of my fault, as the docs around what is returned in the UI are non-existent (improving), as it doesn't return the same shape that the REST API does.

<img width="1138" height="480" alt="image" src="https://github.com/user-attachments/assets/e321034c-dc86-4caa-828c-a9b1fce6bc07" />
 