### PR TITLE
feat(ui): follow CoolerControl's theme colors

### DIFF
--- a/docs/plugin-ui-theming.md
+++ b/docs/plugin-ui-theming.md
@@ -4,13 +4,31 @@ The plugin UI adapts to CoolerControl's theme (dark/light) via CSS variables.
 
 ## CSS Variables
 
+CoolerControl sends the active theme's variables to the plugin iframe, each carrying an
+`r g b` triplet:
+
 ```css
-rgb(var(--colors-bg-one))       /* Primary background */
-rgb(var(--colors-bg-two))       /* Secondary background */
-rgb(var(--colors-border-one))   /* Border */
-rgb(var(--colors-text))         /* Text */
-rgb(var(--colors-accent))       /* Accent / highlights */
-rgb(var(--colors-red))          /* Errors */
+rgb(var(--colors-bg-one))                /* Primary background */
+rgb(var(--colors-bg-two))                /* Secondary background */
+rgb(var(--colors-border-one))            /* Border */
+rgb(var(--colors-text-color))            /* Text */
+rgb(var(--colors-text-color-secondary))  /* Muted text */
+rgb(var(--colors-accent))                /* Accent / highlights */
+rgb(var(--colors-surface-hover))         /* Hover tint */
+rgb(var(--colors-success))               /* Success */
+rgb(var(--colors-warning))               /* Warning */
+rgb(var(--colors-error))                 /* Error / destructive */
+rgb(var(--colors-info))                  /* Informational */
+rgb(var(--colors-accent-gradient-to))    /* Accent gradient end */
+```
+
+Give every one a fallback. It keeps the UI rendering standalone, where no parent
+stylesheet is injected, and on CoolerControl versions that publish a smaller set:
+
+```css
+:root {
+    --bg-one: var(--colors-bg-one, 27 30 35);
+}
 ```
 
 ## Usage
@@ -80,9 +98,10 @@ const { mode } = await getContext(); // 'modal' | 'full_page'
 ## Semantic Colors
 
 - `--colors-accent` — primary actions, highlights
-- `--colors-red` — errors, destructive actions
 - `--colors-bg-one` — content containers
 - `--colors-bg-two` — page background
+- `--colors-text-color` and `--colors-text-color-secondary` for primary and muted text
+- `--colors-success`, `--colors-warning`, `--colors-error`, `--colors-info` for status
 
 ## Reference
 

--- a/etc/coolercontrol/plugins/coolerdash/ui/index.html
+++ b/etc/coolercontrol/plugins/coolerdash/ui/index.html
@@ -9,20 +9,21 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         :root {
-            /* CoolerControl theme CSS variables.
-               These fallback values maintain the original dark theme in standalone/dev mode.
-               When runPluginScript() injects the CC parent stylesheet, CC's :root definitions
-               override these values, making the entire UI automatically adapt to the active theme. */
-            --bg-one: 27 30 35;
-            --bg-two: 44 49 60;
-            --text-color: 234 234 234;
-            --text-color-secondary: 140 145 165;
-            --border-one: 45 66 99;
-            --accent: 86 138 242;
-            --surface-hover: 38 48 78;
-            --success: 34 197 94;
-            --error: 233 69 96;
-            --warning: 255 140 0;
+            /* CoolerControl publishes its active theme as `--colors-*` variables on the
+               parent document, each carrying an `r g b` triplet. Taking them through
+               var() means a theme change in CoolerControl reaches this UI with no work
+               here. The literals are the fallback for standalone/dev mode, where no
+               parent stylesheet is injected, and keep the original dark theme. */
+            --bg-one: var(--colors-bg-one, 27 30 35);
+            --bg-two: var(--colors-bg-two, 44 49 60);
+            --text-color: var(--colors-text-color, 234 234 234);
+            --text-color-secondary: var(--colors-text-color-secondary, 140 145 165);
+            --border-one: var(--colors-border-one, 45 66 99);
+            --accent: var(--colors-accent, 86 138 242);
+            --surface-hover: var(--colors-surface-hover, 38 48 78);
+            --success: var(--colors-success, 34 197 94);
+            --error: var(--colors-error, 233 69 96);
+            --warning: var(--colors-warning, 255 140 0);
             /* Structural — not theme-dependent */
             --radius: 10px;
             --radius-sm: 6px;
@@ -2417,7 +2418,7 @@
                         el.innerHTML = '<strong style="color:rgb(var(--warning))">v' + latest + ' available</strong> &mdash; '
                             + '<a href="' + escapeHtml(dlUrl) + '" target="_blank" rel="noopener noreferrer">Download</a>';
                     } else {
-                        el.innerHTML = '<span style="color:var(--colors-success,#22c55e)">v' + (latest || current) + ' \u2713 up to date</span>';
+                        el.innerHTML = '<span style="color:rgb(var(--success))">v' + (latest || current) + ' \u2713 up to date</span>';
                     }
                 } catch (e) {
                     el.innerHTML = 'v' + current + ' &mdash; <a href="' + releasesUrl + '" target="_blank" rel="noopener noreferrer">Check releases</a>';


### PR DESCRIPTION
Hi again, 

This one is completely up to you, and of course the core issue is that the docs around this are not very clear. I just updated them so that this is much more understandable now. CC 5.0 also has more user-definable colors for the UI, so those have been added, and old CC versions are still handled by your default colors.

Before:
<img width="2153" height="1836" alt="Screenshot_20260824_182610" src="https://github.com/user-attachments/assets/65aa301b-e6c0-43bb-91f3-162ff97e4567" />

After:
<img width="2153" height="1836" alt="Screenshot_20260824_190117" src="https://github.com/user-attachments/assets/eef3dda9-40b0-4537-a954-7bb97691f8fb" />
