### PR TITLE
fix: drop missed render ticks instead of replaying

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -693,8 +693,26 @@ static int run_daemon(Config *config)
 
         draw_display_image(config);
 
-        int sleep_result =
-            clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_time, NULL);
+        /* Absolute deadline: a render or a reload longer than one interval leaves it in
+           the past, and clock_nanosleep then returns at once. Drop the missed ticks
+           rather than replaying them at render speed. */
+        struct timespec now;
+        if (clock_gettime(CLOCK_MONOTONIC, &now) == 0 &&
+            (next_time.tv_sec < now.tv_sec ||
+             (next_time.tv_sec == now.tv_sec && next_time.tv_nsec < now.tv_nsec)))
+        {
+            next_time = now;
+        }
+
+        int sleep_result;
+        while ((sleep_result = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME,
+                                               &next_time, NULL)) == EINTR)
+        {
+            /* The deadline is absolute, so resuming is the same call. Only a shutdown or
+               a reload is worth cutting the interval short for. */
+            if (!running || reload_config)
+                break;
+        }
         if (sleep_result != 0 && sleep_result != EINTR)
         {
             log_message(LOG_WARNING, "Sleep interrupted: %s", strerror(sleep_result));


### PR DESCRIPTION
Hi 👋🏼,

So this one is totally your judgement call, as it's not something that happens very often.

Simply said:
If something hangs the loop up, or something takes longer than the loop length to finish, those "missed" image updates are then fired off as fast as possible until it catches up.

Examples of what could cause this: Unexpected long Image PUTs to CC, configuration reloading problems, sensors request takes longer than expected, the user's processor is very busy, etc.

Testing example using the default Refresh Interval:
```
 20.03s   2.50
 22.52s   2.50
 25.03s   2.51
 27.53s   2.51
         ----   --- SIGSTOP 12s
         ----   --- SIGCONT ---
 41.90s  14.36
 42.28s   0.38
 42.66s   0.38
 43.04s   0.38
 43.42s   0.38
 43.80s   0.38
 45.01s   1.21
 47.53s   2.52
 50.03s   2.50
 52.53s   2.50
 55.03s   2.50
 57.53s   2.50
 60.03s   2.50
 62.53s   2.50
 65.03s   2.50
```